### PR TITLE
Pin conftest to v0.20.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM instrumenta/conftest:latest as conftest
+FROM instrumenta/conftest:v0.20.0 as conftest
 
 FROM golang:1.14-alpine as builder
 COPY main.go .


### PR DESCRIPTION
Pulling from GCS buckets is broken in v0.21.0 (currently latest) so this pins conftest to the latest working version until it is fixed upstream.

Edit -- examples:

```sh
$ docker run --rm -it -v $PWD:/data -e GOOGLE_APPLICATION_CREDENTIALS="/data/gcs.json" instrumenta/conftest:v0.21.0 pull gcs::https://www.googleapis.com/storage/v1/redacted-bucket/policy
Error: download policies: client get: error downloading 'https://www.googleapis.com/storage/v1/yes-k8s-policy/policy': RemoveAll .: invalid argument

$ echo $?
1

$ docker run --rm -it -v $PWD:/data -e GOOGLE_APPLICATION_CREDENTIALS="/data/gcs.json" instrumenta/conftest:v0.20.0 pull gcs::https://www.googleapis.com/storage/v1/redacted-bucket/policy

$ echo $?
0
```