### PR TITLE
Fix getPolicyIDFromMetadata never returning an error

### DIFF
--- a/main.go
+++ b/main.go
@@ -292,7 +292,7 @@ func runConftestTest() ([]jsonCheckResult, error) {
 
 func getPolicyIDFromMetadata(metadata map[string]interface{}, policyIDKey string) (string, error) {
 	details := metadata["details"].(map[string]interface{})
-	if details[policyIDKey] == "" {
+	if details[policyIDKey] == nil {
 		return "", fmt.Errorf("empty policyID key")
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -146,3 +146,16 @@ func TestGetPolicyIDFromMetadata(t *testing.T) {
 		t.Errorf("output %v did not match expected %v", actual, expected)
 	}
 }
+
+func TestGetPolicyIDFromMetadata_Empty(t *testing.T) {
+	metadata := map[string]interface{}{
+		"details": map[string]interface{}{
+			"test": "TEST",
+		},
+	}
+
+	_, err := getPolicyIDFromMetadata(metadata, "policyID")
+	if err == nil {
+		t.Errorf("should error when policyIDKey does not exist")
+	}
+}


### PR DESCRIPTION
Should check for `nil` instead of an empty string.