### PR TITLE
Don't use a special case for message formatting based on policyID

### DIFF
--- a/.github/test/policy/always_warn.rego
+++ b/.github/test/policy/always_warn.rego
@@ -1,10 +1,13 @@
 package always_warn
 
 warn[msg] {
-    msg := {
-        "msg": "a warning! you should probably fix this",
-        "details": {"policyID": "P0000"}
-    }
-
+    msg := format_with_id("a warning! you should probably fix this", "P0000")
     true
+}
+
+format_with_id(msg, id) = msg_fmt {
+    msg_fmt := {
+        "msg": sprintf("%s: %s", [id, msg]),
+        "details": {"policyID": id}
+    }
 }

--- a/main.go
+++ b/main.go
@@ -114,30 +114,22 @@ func run() error {
 		successes += len(result.Successes)
 
 		for _, fail := range result.Failures {
-			// attempt to parse the policy ID section, skip if there are errors
+			fails = append(fails, fmt.Sprintf("%s - %s", result.Filename, fail.Message))
 			policyID, err := getPolicyIDFromMetadata(fail.Metadata, policyIDKey)
 			if err != nil {
-				fails = append(fails, fmt.Sprintf("%s - %s", result.Filename, fail.Message))
 				continue
 			}
-
-			fails = append(fails, fmt.Sprintf("%s - %s: %s", result.Filename, policyID, fail.Message))
-
 			if !contains(policiesWithFails, policyID) {
 				policiesWithFails = append(policiesWithFails, policyID)
 			}
 		}
 
 		for _, warn := range result.Warnings {
-			// attempt to parse the policy ID section, skip if there are errors
+			warns = append(warns, fmt.Sprintf("%s - %s", result.Filename, warn.Message))
 			policyID, err := getPolicyIDFromMetadata(warn.Metadata, policyIDKey)
 			if err != nil {
-				warns = append(warns, fmt.Sprintf("%s - %s", result.Filename, warn.Message))
 				continue
 			}
-
-			warns = append(warns, fmt.Sprintf("%s - %s: %s", result.Filename, policyID, warn.Message))
-
 			if !contains(policiesWithWarns, policyID) {
 				policiesWithWarns = append(policiesWithWarns, policyID)
 			}


### PR DESCRIPTION
Instead of handling this case in the action, the `format()` function should include the policy ID if one is specified, this way the policy ID is shown to the user regardless of where they are running the policy. EG: https://github.com/plexsystems/konstraint/blob/f2e60d22ee5d589ea5e663aa49357e8505c68d81/examples/lib/core.rego#L22-L27