### PR TITLE
Bump GitHub action versions

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -7,12 +7,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: setup go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.15.x
 
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: unit test
         run: go test -v ./...
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: run action
         uses: './'

--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: conftest
-        uses: YubicoLabs/action-conftest@v2
+        uses: YubicoLabs/action-conftest@v3
         with:
           files: some_deployment.yaml another_resource.yaml
           gh-token: ${{ secrets.GITHUB_TOKEN }}
@@ -61,9 +61,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: conftest
-        uses: YubicoLabs/action-conftest@v2
+        uses: YubicoLabs/action-conftest@v3
         with:
           files: some_deployment.yaml another_resource.yaml
           pull-url: gcs::https://www.googleapis.com/storage/v1/bucket_name/policy
@@ -82,9 +82,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: conftest
-        uses: YubicoLabs/action-conftest@v2
+        uses: YubicoLabs/action-conftest@v3
         with:
           files: some_deployment.yaml another_resource.yaml
           gh-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The new versions use Node 16 by default instead of the now-deprecated Node 12. https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

Actions updated:
* actions/checkout to v3
* actions/setup-go to v3