### PR TITLE
Harden policy metadata handling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/YubicoLabe/action-conftest
+
+go 1.23

--- a/main.go
+++ b/main.go
@@ -122,11 +122,17 @@ func run() error {
 	var policiesWithFails, policiesWithWarns []string
 	var fails, warns []string
 	var successes int
+
 	for _, result := range results {
 		successes += result.Successes
 
 		for _, fail := range result.Failures {
 			fails = append(fails, fmt.Sprintf("%s - %s", result.FileName, fail.Message))
+
+			if metricsURL == "" || policyIDKey == "" {
+				continue
+			}
+
 			policyID, err := getPolicyIDFromMetadata(fail.Metadata, policyIDKey)
 			if err != nil {
 				continue
@@ -138,6 +144,11 @@ func run() error {
 
 		for _, warn := range result.Warnings {
 			warns = append(warns, fmt.Sprintf("%s - %s", result.FileName, warn.Message))
+
+			if metricsURL == "" || policyIDKey == "" {
+				continue
+			}
+
 			policyID, err := getPolicyIDFromMetadata(warn.Metadata, policyIDKey)
 			if err != nil {
 				continue
@@ -295,12 +306,29 @@ func runConftestTest() ([]CheckResult, error) {
 }
 
 func getPolicyIDFromMetadata(metadata map[string]interface{}, policyIDKey string) (string, error) {
-	details := metadata["details"].(map[string]interface{})
-	if details[policyIDKey] == nil {
-		return "", fmt.Errorf("empty policyID key")
+	if metadata == nil {
+		return "", fmt.Errorf("metadata is nil")
+	}
+	if policyIDKey == "" {
+		return "", fmt.Errorf("policyIDKey is empty")
 	}
 
-	return fmt.Sprintf("%v", details[policyIDKey]), nil
+	rawDetails, ok := metadata["details"]
+	if !ok || rawDetails == nil {
+		return "", fmt.Errorf("missing details in metadata")
+	}
+
+	details, ok := rawDetails.(map[string]interface{})
+	if !ok {
+		return "", fmt.Errorf("details has unexpected type %T", rawDetails)
+	}
+
+	val, ok := details[policyIDKey]
+	if !ok || val == nil {
+		return "", fmt.Errorf("empty policyID key %q", policyIDKey)
+	}
+
+	return fmt.Sprintf("%v", val), nil
 }
 
 func getFlagsFromEnv() []string {

--- a/main_test.go
+++ b/main_test.go
@@ -159,3 +159,31 @@ func TestGetPolicyIDFromMetadata_Empty(t *testing.T) {
 		t.Errorf("should error when policyIDKey does not exist")
 	}
 }
+
+func TestGetPolicyIDFromMetadata_NilMetadata(t *testing.T) {
+	var metadata map[string]interface{} = nil
+
+	if _, err := getPolicyIDFromMetadata(metadata, "policyID"); err == nil {
+		t.Errorf("expected error when metadata is nil")
+	}
+}
+
+func TestGetPolicyIDFromMetadata_NoDetails(t *testing.T) {
+	metadata := map[string]interface{}{
+		"somethingElse": "value",
+	}
+
+	if _, err := getPolicyIDFromMetadata(metadata, "policyID"); err == nil {
+		t.Errorf("expected error when details is missing")
+	}
+}
+
+func TestGetPolicyIDFromMetadata_DetailsWrongType(t *testing.T) {
+	metadata := map[string]interface{}{
+		"details": "not-a-map",
+	}
+
+	if _, err := getPolicyIDFromMetadata(metadata, "policyID"); err == nil {
+		t.Errorf("expected error when details is wrong type")
+	}
+}


### PR DESCRIPTION
* Fix a panic in getPolicyIDFromMetadata by defensively handling nil or malformed metadata returned by conftest results, and add tests covering missing metadata and details cases.
* Add go.mod/go.sum for module-based builds and testing.

This prevents action-conftest from crashing when policies emit results without metadata, especially when metrics are enabled.

This is for https://github.com/YubicoLabs/action-conftest/issues/8.